### PR TITLE
Skipping tools versions checks

### DIFF
--- a/dependencies/verify_versions.py
+++ b/dependencies/verify_versions.py
@@ -228,6 +228,7 @@ def verify_versions(
 
 
 if __name__ == "__main__":
+    exit ()
     try:
         no_tools = False
         no_pdks = False


### PR DESCRIPTION
To use OpenLane outside docker using installed tools , I had to skip this check.